### PR TITLE
Small bug fixes and game object counter onscreen

### DIFF
--- a/samples/asteroids/components/fps_component.rb
+++ b/samples/asteroids/components/fps_component.rb
@@ -6,8 +6,23 @@ module Asteroids
       @fps_counter = game_object.ui_renderers.first
     end
 
+    def onscreen_message
+      [
+        "FPS: #{Engine.fps.round(4)}",
+        "Total Game Objects: #{Engine::GameObject.objects.count}",
+        "",
+        "#{game_objects_tallied}"
+      ].join("\n")
+    end
+
     def update(delta_time)
-      @fps_counter.update_string("FPS: #{Engine.fps.round(4)}")
+      @fps_counter.update_string(onscreen_message)
+    end
+
+    def game_objects_tallied
+      Engine::GameObject.objects.map(&:name).tally.map do |game_obj, count|
+        "#{game_obj} (#{count})"
+      end.join("\n")
     end
   end
 end

--- a/samples/asteroids/components/fps_component.rb
+++ b/samples/asteroids/components/fps_component.rb
@@ -4,6 +4,16 @@ module Asteroids
   class FpsComponent < Engine::Component
     def start
       @fps_counter = game_object.ui_renderers.first
+      @display = false
+    end
+
+    def update(delta_time)
+      toggle_visibility if Engine::Input.key_down?(GLFW::KEY_D)
+      @fps_counter.update_string( @display ? onscreen_message : '' )
+    end
+
+    def toggle_visibility
+      @display = !@display
     end
 
     def onscreen_message
@@ -15,9 +25,6 @@ module Asteroids
       ].join("\n")
     end
 
-    def update(delta_time)
-      @fps_counter.update_string(onscreen_message)
-    end
 
     def game_objects_tallied
       Engine::GameObject.objects.map(&:name).tally.map do |game_obj, count|

--- a/samples/asteroids/components/ship/shield.rb
+++ b/samples/asteroids/components/ship/shield.rb
@@ -7,11 +7,8 @@ module Asteroids
       @shield_colour = { r: 1, g: 1, b: 1 }
     end
 
-    def ship
-      @ship ||= game_object.parent
-    end
-
     def update(delta_time)
+      @ship_pos = game_object.parent.pos
       detect_collision_with_asteroids
       set_shield_colour
       destroy_shield! if @shield_health <= 0
@@ -20,11 +17,11 @@ module Asteroids
     def detect_collision_with_asteroids
       AsteroidComponent.asteroids.each do |asteroid|
         next if asteroid.destroyed?
-        if (ship.pos - asteroid.game_object.pos).magnitude < asteroid.size
+        if (@ship_pos - asteroid.game_object.pos).magnitude < asteroid.size
           inflict_shield_damage(asteroid.size)
           asteroid.blow_up
 
-          Explosion.create(ship.pos)
+          Explosion.create(@ship_pos)
         end
       end
     end
@@ -36,7 +33,7 @@ module Asteroids
 
     def destroy_shield!
       game_object.destroy!
-      Explosion.create(ship.pos, colour: { r: 0.5, g: 1, b: 1 })
+      Explosion.create(@ship_pos, colour: { r: 0.5, g: 1, b: 1 })
     end
 
     def set_shield_colour

--- a/samples/asteroids/components/ship/shield.rb
+++ b/samples/asteroids/components/ship/shield.rb
@@ -22,7 +22,7 @@ module Asteroids
         next if asteroid.destroyed?
         if (ship.pos - asteroid.game_object.pos).magnitude < asteroid.size
           inflict_shield_damage(asteroid.size)
-          asteroid.destroy!
+          asteroid.blow_up
 
           Explosion.create(ship.pos)
         end

--- a/samples/asteroids/game_objects/explosion.rb
+++ b/samples/asteroids/game_objects/explosion.rb
@@ -24,7 +24,8 @@ module Asteroids
             20,
             false,
             colour
-          )
+          ),
+          DestroyAfter.new(1)
         ]
       )
     end

--- a/samples/asteroids/game_objects/onscreen_ui.rb
+++ b/samples/asteroids/game_objects/onscreen_ui.rb
@@ -7,7 +7,7 @@ module Asteroids
 
     def self.create
       parent = Engine::GameObject.new("FPS Counter Container")
-      parent.add_child Text.create(Vector[TEXT_SIZE / 2, Engine::Window.height - TEXT_SIZE / 2, UI_Z_ORDER], 0, TEXT_SIZE, "FPS: ", components: [ Asteroids::FpsComponent.new ])
+      parent.add_child Text.create(Vector[TEXT_SIZE, Engine::Window.height - TEXT_SIZE, UI_Z_ORDER], 0, TEXT_SIZE, "FPS: ", components: [ Asteroids::FpsComponent.new ])
     end
   end
 end

--- a/samples/asteroids/game_objects/onscreen_ui.rb
+++ b/samples/asteroids/game_objects/onscreen_ui.rb
@@ -2,7 +2,7 @@
 
 module Asteroids
   module OnscreenUI
-    TEXT_SIZE = 50
+    TEXT_SIZE = 30
     UI_Z_ORDER = 0
 
     def self.create


### PR DESCRIPTION
# What
Expanded the use of the FPS counter to display a counter for the game objects and each of the game objects names.

This made it easy to spot that the `Explosion` objects were never destroyed, so I've added a `DestroyAfter.new(1)` to the component.

> [!NOTE]
> I've updated to use a tallied count of object names (previously I was just listing every one of them).   
> One thing that's a bit awkward is that when `Explosion` objects are destroyed, there's still a lingering partial output in the list, making me think that `update_string`'s buffer isn't properly being flushed or something.

## Bugfixes
- reverting `shader_camera_matrix` changes, since it's messing with the view:
  > \# When the ship, or an asteroid, flies off the screen, it takes a while before it comes back onto the screen
- updating the shield to trigger `asteroid.blow_up` on collsion (otherwise it just creates lots of explosions without triggering `asteroid.split`, etc., and causes lots of game objects to be created)

## Tweaks
I made a slight change to the FPS counter display (font size and positioning).
It's a bit awkward on 1444 x 900, making me think that some of the calcuation is off.
To get it in the top left corner I was using:
``` ruby
parent.add_child Text.create(Vector[TEXT_SIZE, (WINDOW_HEIGHT * 2)- TEXT_SIZE, UI_Z_ORDER],
```
but at 1920 x 1080, that's way off screen.